### PR TITLE
Wait to remove insertion revisions until they are all processed

### DIFF
--- a/libmat2/office.py
+++ b/libmat2/office.py
@@ -283,9 +283,15 @@ class MSOfficeParser(ZipParser):
                     for children in element.iterfind('./*'):
                         elements_ins.append((element, position, children))
                     break
+
         for (element, position, children) in elements_ins:
             parent_map[element].insert(position, children)
-            parent_map[element].remove(element)
+            
+        # the list can sometimes contain duplicate elements, so don't remove
+        # until all children have been processed
+        for (element, position, children) in elements_ins:
+            if element in parent_map[element]:
+                parent_map[element].remove(element)
 
         tree.write(full_path, xml_declaration=True, encoding='utf-8')
         return True


### PR DESCRIPTION
Sometimes when you try to clean a docx file with revisions you get a `x not in list` error:

```python
concurrent.futures.process._RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/process.py", line 263, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex-marchant/Developer/mat2/mat2", line 142, in clean_meta
    ret = p.remove_all()
          ^^^^^^^^^^^^^^
  File "/Users/alex-marchant/Developer/mat2/libmat2/archive.py", line 224, in remove_all
    if self._specific_cleanup(full_path) is False:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex-marchant/Developer/mat2/libmat2/office.py", line 462, in _specific_cleanup
    if self.__remove_revisions(full_path) is False:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex-marchant/Developer/mat2/libmat2/office.py", line 288, in __remove_revisions
    parent_map[element].remove(element)
ValueError: list.remove(x): x not in list
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/alex-marchant/Developer/mat2/./mat2", line 231, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/alex-marchant/Developer/mat2/./mat2", line 226, in main
    no_failure &= future.result()
                  ^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
ValueError: list.remove(x): x not in list
```

The fix I found for this was to wait until all insertions were processed, before calling "remove". Also, it checks to make sure the element still exists before calling remove.

Here is a file that should replicate for you:

[revisions.docx](https://github.com/user-attachments/files/16985746/revisions.docx)