### PR TITLE
Fix test_climat2 failure on Python 3.15

### DIFF
--- a/tests/test_climat2.py
+++ b/tests/test_climat2.py
@@ -24,12 +24,12 @@ class TestHelp(unittest.TestCase):
         self.assertIn(b'mat2 [-h] [-V]', stdout)
         self.assertIn(b'[--unknown-members policy]', stdout)
         self.assertIn(b'[--inplace]', stdout)
-        self.assertIn(b'[-v]', stdout)
-        self.assertIn(b'[-l]', stdout)
-        self.assertIn(b'[--check-dependencies]', stdout)
+        self.assertIn(b'-v', stdout)
+        self.assertIn(b'-l', stdout)
+        self.assertIn(b'--check-dependencies', stdout)
         self.assertIn(b'[-L', stdout)
         self.assertIn(b'-s]', stdout)
-        self.assertIn(b'[files ...]', stdout)
+        self.assertIn(b'files', stdout)
 
     def test_no_arg(self):
         proc = subprocess.Popen(mat2_binary, stdout=subprocess.PIPE)
@@ -37,12 +37,12 @@ class TestHelp(unittest.TestCase):
         self.assertIn(b'mat2 [-h] [-V]', stdout)
         self.assertIn(b'[--unknown-members policy]', stdout)
         self.assertIn(b'[--inplace]', stdout)
-        self.assertIn(b'[-v]', stdout)
-        self.assertIn(b'[-l]', stdout)
-        self.assertIn(b'[--check-dependencies]', stdout)
+        self.assertIn(b'-v', stdout)
+        self.assertIn(b'-l', stdout)
+        self.assertIn(b'--check-dependencies', stdout)
         self.assertIn(b'[-L', stdout)
         self.assertIn(b'-s]', stdout)
-        self.assertIn(b'[files ...]', stdout)
+        self.assertIn(b'files', stdout)
 
 
 class TestVersion(unittest.TestCase):


### PR DESCRIPTION
Hi, I maintain the mat2 package for Fedora.

The Fedora Python SIG is currently testing builds against Python 3.15 (preview for Fedora 45), and mat2 fails to build because Python 3.15 changed the formatting of argparse help output (removing brackets [] around options).

This PR relaxes the assertions in test_climat2.py to check for the presence of the flags (e.g. -v) rather than the exact bracketed formatting.

We are currently applying this patch in Fedora to unblock our builds, and it works correctly on both Python 3.15 and older versions.

Build logs: https://copr-be.cloud.fedoraproject.org/results/@python/python3.15/fedora-rawhide-x86_64/09935245-mat2/