### PR TITLE
Strip APEv2 and ID3v1 tags appended to mp3, ogg and flac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Remove APEv2 and ID3v1 tags appended to mp3, ogg and flac files
+
 # 0.14.0 - 2025-10-23
 - Add webp support
 - Improve reliability

--- a/libmat2/audio.py
+++ b/libmat2/audio.py
@@ -7,6 +7,8 @@ import tempfile
 from typing import Union, Dict
 
 import mutagen
+import mutagen.apev2
+import mutagen.id3
 
 from . import abstract, parser_factory, video
 
@@ -26,6 +28,15 @@ class MutagenParser(abstract.AbstractParser):
             return {k: ', '.join(map(str, v)) for k, v in f.tags.items()}
         return {}
 
+    def _remove_appended_tags(self) -> None:
+        """ mutagen.File() only binds the container's primary tag, so an APEv2
+        or ID3 block glued to the file is left untouched by delete(). """
+        for module in (mutagen.apev2, mutagen.id3):
+            try:
+                module.delete(self.output_filename)
+            except mutagen.MutagenError as e:
+                raise ValueError(e)
+
     def remove_all(self) -> bool:
         shutil.copy(self.filename, self.output_filename)
         f = mutagen.File(self.output_filename)
@@ -34,6 +45,7 @@ class MutagenParser(abstract.AbstractParser):
             f.save()
         except mutagen.MutagenError as e:
             raise ValueError(e)
+        self._remove_appended_tags()
         return True
 
 
@@ -68,6 +80,7 @@ class FLACParser(MutagenParser):
         f.clear_pictures()
         f.delete()
         f.save(deleteid3=True)
+        self._remove_appended_tags()
         return True
 
     def get_meta(self) -> Dict[str, Union[str, Dict]]:

--- a/tests/test_libmat2.py
+++ b/tests/test_libmat2.py
@@ -9,6 +9,9 @@ import tarfile
 import tempfile
 import zipfile
 
+import mutagen
+import mutagen.apev2
+
 from libmat2 import pdf, images, audio, office, parser_factory, torrent, harmless
 from libmat2 import check_dependencies, video, archive, web, epub
 
@@ -321,6 +324,68 @@ class TestRevisionsCleaning(unittest.TestCase):
 
         os.remove('./tests/data/revision_clean.docx')
         os.remove('./tests/data/revision_clean.cleaned.docx')
+
+
+class TestAppendedTagsCleaning(unittest.TestCase):
+    """ APEv2 and ID3v1 blocks are appended after the audio data, and aren't
+    the primary tag of any of those containers. """
+
+    @staticmethod
+    def __append_apev2(filename: str) -> None:
+        tag = mutagen.apev2.APEv2()
+        tag['Artist'] = 'jvoisin'
+        tag['Comment'] = 'I am an appended tag'
+        tag.save(filename)
+
+    @staticmethod
+    def __append_id3v1(filename: str) -> None:
+        # mutagen refuses to write ID3 on non-ID3 containers, hence the
+        # handrolled 128 bytes: TAG, title, artist, album, year, comment, genre
+        tag = b'TAG'
+        for value, size in (('I am so', 30), ('jvoisin', 30), ('harmfull', 30),
+                            ('1337', 4), ('I am an appended tag', 30)):
+            tag += value.encode('utf-8').ljust(size, b'\x00')
+        with open(filename, 'ab') as f:
+            f.write(tag + b'\xff')
+
+    def __leftovers(self, extension: str, parser, append, needles) -> list:
+        """ Clean a file carrying an appended tag, and return the needles that
+        are still in it. Printing the whole file on failure isn't helpful. """
+        target = './tests/data/appended.' + extension
+        shutil.copy('./tests/data/dirty.' + extension, target)
+        append(target)
+
+        p = parser(target)
+        self.assertTrue(p.remove_all())
+
+        with open(p.output_filename, 'rb') as f:
+            content = f.read()
+
+        # the cleaned file must still be a readable audio file
+        self.assertIsNotNone(mutagen.File(p.output_filename))
+
+        os.remove(target)
+        os.remove(p.output_filename)
+        return [n.decode('utf-8') for n in needles if n in content]
+
+    def test_apev2(self):
+        needles = (b'APETAGEX', b'I am an appended tag')
+        for extension, parser in (('mp3', audio.MP3Parser),
+                                  ('ogg', audio.OGGParser),
+                                  ('flac', audio.FLACParser)):
+            with self.subTest(extension=extension):
+                left = self.__leftovers(extension, parser,
+                                        self.__append_apev2, needles)
+                self.assertEqual(left, [])
+
+    def test_id3v1(self):
+        needles = (b'I am an appended tag', )
+        for extension, parser in (('ogg', audio.OGGParser),
+                                  ('flac', audio.FLACParser)):
+            with self.subTest(extension=extension):
+                left = self.__leftovers(extension, parser,
+                                        self.__append_id3v1, needles)
+                self.assertEqual(left, [])
 
 
 class TestCleaning(unittest.TestCase):


### PR DESCRIPTION
`MutagenParser.remove_all()` calls `mutagen.File()` and then `.delete()`. Generic `mutagen.File()` binds only the container's primary tag: ID3v2 for mp3, Vorbis comments for ogg and flac. An APEv2 block sitting after the audio data is none of those, so it goes through cleaning untouched.

On 656ab73:

```
$ python3 -c "
import mutagen.apev2, shutil
shutil.copy('tests/data/dirty.mp3', 'leak.mp3')
t = mutagen.apev2.APEv2()
t['Artist'] = 'Real Name'
t['Comment'] = '48.8584, 2.2945'
t.save('leak.mp3')"

$ ./mat2 leak.mp3

$ python3 -c "import mutagen.apev2; print(mutagen.apev2.APEv2('leak.cleaned.mp3'))"
{'Artist': APETextValue('Real Name', 0), 'Comment': APETextValue('48.8584, 2.2945', 0)}

$ cmp <(tail -c 100 leak.mp3) <(tail -c 100 leak.cleaned.mp3) && echo identical
identical
```

The tag survives byte for byte. APEv2 on mp3 is not exotic. mp3gain stores its gain and undo info there, foobar2000 will tag that way, and anything built on mutagen or TagLib reads it back.

ID3v1 has the same hole on ogg. It is 128 bytes glued to the end of the file, and `OggVorbis.delete()` never looks there. flac is already covered because `FLACParser` passes `save(deleteid3=True)`.

Four leaking cases:

| appended tag | mp3 | ogg | flac |
| --- | --- | --- | --- |
| APEv2 | survives | survives | survives |
| ID3v1 | removed | survives | removed |

The fix deletes both explicitly on the output file with mutagen's module-level `apev2.delete()` and `id3.delete()`. Both are no-ops when the tag isn't there. mutagen's `find_id3v1()` already knows not to mistake an APEv2 footer for an ID3v1 header, so the order of the two calls doesn't matter, I checked both.

`TestAppendedTagsCleaning` builds the fixtures in-process. APEv2 goes through mutagen; the ID3v1 block is handrolled because mutagen won't write ID3 onto an ogg. Then it cleans and greps the output bytes. On master it fails on exactly the four cases above:

```
$ python3 -m unittest tests.test_libmat2.TestAppendedTagsCleaning -v
test_apev2 (tests.test_libmat2.TestAppendedTagsCleaning.test_apev2) ...
  test_apev2 (...) (extension='mp3') ... FAIL
  test_apev2 (...) (extension='ogg') ... FAIL
  test_apev2 (...) (extension='flac') ... FAIL
test_id3v1 (tests.test_libmat2.TestAppendedTagsCleaning.test_id3v1) ...
  test_id3v1 (...) (extension='ogg') ... FAIL

======================================================================
FAIL: test_apev2 (tests.test_libmat2.TestAppendedTagsCleaning.test_apev2) (extension='mp3')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/test_libmat2.py", line 379, in test_apev2
    self.assertEqual(left, [])
    ~~~~~~~~~~~~~~~~^^^^^^^^^^
AssertionError: Lists differ: ['APETAGEX', 'I am an appended tag'] != []

[the ogg and flac failures are the same list, the ogg ID3v1 one is
 ['I am an appended tag']]

----------------------------------------------------------------------
Ran 2 tests in 0.023s

FAILED (failures=4)
```

Note that the flac + ID3v1 subtest passes on master, which is the `deleteid3=True` already doing its job.

With the patch:

```
$ python3 -m unittest tests.test_libmat2.TestAppendedTagsCleaning -v
test_apev2 (tests.test_libmat2.TestAppendedTagsCleaning.test_apev2) ... ok
test_id3v1 (tests.test_libmat2.TestAppendedTagsCleaning.test_id3v1) ... ok

Ran 2 tests in 0.018s

OK
```

Full suite, master then this branch:

```
$ python3 -m unittest discover
Ran 123 tests in 98.324s
OK (skipped=1)

$ python3 -m unittest discover
Ran 125 tests in 70.279s
OK (skipped=1)
```

The cleaned files still decode. I tagged the three dirty fixtures with APEv2, cleaned them, and ffprobe reads all three back at the original 2.033560s with the audio stream bit-identical to the input:

```
$ for e in mp3 ogg flac; do
    ffprobe -v error -show_entries format=format_name,duration -of default=nw=1 ape.cleaned.$e
  done
format_name=mp3
duration=2.033560
format_name=ogg
duration=2.033560
format_name=flac
duration=2.033560

$ for e in mp3 ogg flac; do
    a=$(ffmpeg -v error -i tests/data/dirty.$e -map 0:a -f md5 - 2>/dev/null)
    b=$(ffmpeg -v error -i ape.cleaned.$e -map 0:a -f md5 - 2>/dev/null)
    printf '%-5s %s %s\n' "$e" "$a" "$b"
  done
mp3   MD5=ee0170ff961fda9e3fcdee78a42f88e9 MD5=ee0170ff961fda9e3fcdee78a42f88e9
ogg   MD5=7445794a2192deed18bd57c09e5c5f50 MD5=7445794a2192deed18bd57c09e5c5f50
flac  MD5=9713d983cf2dfd8b1435aaf03c1c02d7 MD5=9713d983cf2dfd8b1435aaf03c1c02d7
```

I put a changelog line under an `Unreleased` heading since master is past 0.14.0. Move or drop it as you like.