### PR TITLE
Sort xml attributes instead of reordering elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Remove APEv2 and ID3v1 tags appended to mp3, ogg and flac files
 - Add avif support
 - Add jpeg xl (jxl) support
+- Stop reordering elements in office files, only sort their attributes
 
 # 0.14.0 - 2025-10-23
 - Add webp support

--- a/libmat2/office.py
+++ b/libmat2/office.py
@@ -37,8 +37,12 @@ def _sort_xml_attributes(full_path: str) -> bool:
     """
     tree = ET.parse(full_path)
 
-    for c in tree.getroot():
-        c[:] = sorted(c, key=lambda child: (child.tag, child.get('desc')))
+    for element in tree.iter():
+        if len(element.attrib) < 2:
+            continue
+        attributes = sorted(element.attrib.items())
+        element.attrib.clear()
+        element.attrib.update(attributes)
 
     tree.write(full_path, xml_declaration=True, encoding='utf-8')
     return True

--- a/tests/test_libmat2.py
+++ b/tests/test_libmat2.py
@@ -970,6 +970,44 @@ class TestCleaningArchives(unittest.TestCase):
         os.remove('./tests/data/dirty.cleaned.cleaned.tar.xz')
 
 
+class TestXmlAttributeSorting(unittest.TestCase):
+    """ OOXML schemas are sequences: the order of the elements carries meaning,
+    only the order of the attributes doesn't. """
+
+    def test_attributes_are_sorted(self):
+        with tempfile.NamedTemporaryFile(suffix='.xml') as f:
+            f.write(b'<r><e z="1" a="2" m="3"/></r>')
+            f.flush()
+            self.assertTrue(office._sort_xml_attributes(f.name))
+            with open(f.name, 'rb') as g:
+                self.assertIn(b'<e a="2" m="3" z="1"', g.read())
+
+    def test_element_order_is_kept(self):
+        with tempfile.NamedTemporaryFile(suffix='.xml') as f:
+            f.write(b'<document><body><p/><tbl/><p/><sectPr/></body></document>')
+            f.flush()
+            self.assertTrue(office._sort_xml_attributes(f.name))
+            with open(f.name, 'rb') as g:
+                content = g.read()
+            self.assertEqual(re.findall(rb'<(\w+)\s*/>', content),
+                             [b'p', b'tbl', b'p', b'sectPr'])
+
+    def test_pptx_slide_layout_is_preserved(self):
+        # <p:cSld> is a sequence, <p:spTree> comes before <p:extLst>
+        target = './tests/data/ordering.pptx'
+        shutil.copy('./tests/data/narrated_powerpoint_presentation.pptx', target)
+        p = office.MSOfficeParser(target)
+        self.assertTrue(p.remove_all())
+
+        with zipfile.ZipFile(p.output_filename) as zipin:
+            slide = zipin.read('ppt/slides/slide1.xml')
+        self.assertEqual(re.findall(rb'<p:(spTree|extLst)[ />]', slide)[:2],
+                         [b'spTree', b'extLst'])
+
+        os.remove(target)
+        os.remove(p.output_filename)
+
+
 class TestComplexOfficeFiles(unittest.TestCase):
     def test_complex_pptx(self):
         target = './tests/data/clean.pptx'


### PR DESCRIPTION
`_sort_xml_attributes` sorts the children of every child of the root. It never touches an attribute. OOXML schemas are sequences, so this reorders the document instead of normalising it.

On `tests/data/narrated_powerpoint_presentation.pptx` the `<p:extLst>` ends up before `<p:spTree>` inside `<p:cSld>`, on all 8 slides. CT_CommonSlideData wants spTree first. A docx alternating paragraphs and tables comes back as every `<w:p>`, then `<w:sectPr>`, then every `<w:tbl>`. That leaves `w:sectPr` no longer last in `<w:body>`.

Attributes were not getting sorted either. ElementTree stopped sorting them on write in 3.8, so the fingerprinting goal is not currently met at all.

@alexmarchant raised this in #5 and it never got split out of that PR. You replied there that any stable order is fine. So this sorts the attributes and leaves the elements alone. It may be behind #18, #45 and #46, but I have no copy of Word or Excel to confirm the repair prompt goes away.

Three tests added. All three fail on 8d41c93. The suite goes from 126 to 129 passing with nothing else changed.
